### PR TITLE
add command to install go dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Binaries for handling SQS Dead Letter Queues:
 
 ### sqs-dead-letter-requeue
 ```sh
+go get -d ./...
 go build -o bin/sqs-dead-letter-requeue sqs-dead-letter-requeue/main.go
 ```
 


### PR DESCRIPTION
If I just followed the directions, I got errors like:

```
sqs-dead-letter-requeue/main.go:8:2: cannot find package "github.com/aws/aws-sdk-go/aws/session" in any of ...
```

It took some googling around and many red herring solutions to find the right stackoverflow answer for this.  I think this would be helpful for newbies to go